### PR TITLE
Fixed a pair of bugs

### DIFF
--- a/cfcs/RemoteProxy.cfc
+++ b/cfcs/RemoteProxy.cfc
@@ -23,7 +23,7 @@ component extends="mura.plugin.pluginGenericEventHandler"{
     
     function getResponseCookies(response){
         var cookies    = structNew();
-        var temp       = structNew()
+        var temp       = structNew();
         var theCookie  = "";
         var cookiePair = [];
         var i          = 0;

--- a/displayObjects/ColdboxRequest.cfc
+++ b/displayObjects/ColdboxRequest.cfc
@@ -4,7 +4,10 @@
 		<cfscript>
 			var proxyPlugin = event.getValue(pluginConfig.getSetting('RemoteAppKey'));
 			var params = deserializeJSON( $.event().getValue("params") );
-			params.properties = deserializeJSON( params.properties );
+			if (isSimpleValue(params.properties)) {
+				/* params.properties may already be an array or object, making this line unnecessary */
+				params.properties = deserializeJSON( params.properties );
+			}
 		
 			var callParameters = structNew();
 			callParameters.event = params.event;


### PR DESCRIPTION
When using this plugin, I was given an error about `JSONDecode(params.properties)` (line 6 of `ColdboxRequest.cfc`), which I made conditional.

The big change, however, is in the `getResponseCookies` method of `RemoteProxy.cfc`. I was having trouble with cookies not being passed back and forth reliably, so I changed the method to consistently return a struct mapping cookie-key to cookie-value. It doesn't seem like your cookie passing method has any way to specify advanced cookie properties, like expiration date or path, so I simply discarded those. If this is incorrect, let me know, and I will address it in another commit.
